### PR TITLE
feat: configure dynamic throttle rate endpoint

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,19 @@
+name: go-test
+on: [pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.23.x'
+      - name: Install dependencies
+        run: go get .
+      - name: Build
+        run: go build -v ./...
+      - name: Test with the Go CLI
+        run: go test -v

--- a/handlers.go
+++ b/handlers.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"math/rand/v2"
+	"net/http"
+	"strconv"
+
+	"go.uber.org/zap"
+)
+
+// ThrottleResponse represents the JSON response structure
+type ThrottleResponse struct {
+	Rate    int    `json:"rate"`
+	Message string `json:"message,omitempty"`
+	Error   string `json:"error,omitempty"`
+}
+
+// Response represents the structure of our JSON response
+type Response struct {
+	UnprocessedTraceSegments []TraceSegment `json:"UnprocessedTraceSegments"`
+}
+
+// TraceSegment represents each segment in the response
+type TraceSegment struct {
+	Id        string `json:"Id"`
+	ErrorCode string `json:"ErrorCode"`
+	Message   string `json:"Message"`
+}
+
+// ThrottledException represents the structure of the error response
+type ThrottledException struct {
+	Message string `json:"message"`
+	Type    string `json:"__type"`
+}
+
+func handleSetOK(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	statusManager.SetOK()
+	w.WriteHeader(http.StatusOK)
+}
+
+func handleSetThrottled(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+
+	// Get and validate rate parameter
+	rate := r.URL.Query().Get("rate")
+	rateValue := 100 // Default value
+
+	if rate != "" {
+		var err error
+		rateValue, err = strconv.Atoi(rate)
+		if err != nil {
+			logger.Warn("rate is not a number")
+			http.Error(w, "rate is not a number", http.StatusBadRequest)
+			return
+		}
+
+		if rateValue < 0 || rateValue > 100 {
+			logger.Info("rate out of range",
+				zap.Int("rate", rateValue),
+			)
+			logger.Warn("rate out of range")
+			http.Error(w, "rate out of range", http.StatusBadRequest)
+			return
+		}
+	}
+
+	response := ThrottleResponse{
+		Rate:    rateValue,
+		Message: fmt.Sprintf("throttle rate set to: %d%%", rateValue),
+	}
+
+	statusManager.SetThrottled(rateValue)
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(response)
+}
+
+func handleTraceSegments(w http.ResponseWriter, r *http.Request) {
+	logger.Info("Received request",
+		zap.String("method", r.Method),
+		zap.String("path", r.URL.Path),
+		zap.String("user_agent", r.UserAgent()),
+	)
+
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	status, rate := statusManager.GetStatus()
+
+	if status == StatusThrottled {
+		// generate a random number
+		prob := rand.IntN(100)
+
+		if prob < rate {
+			response := ThrottledException{
+				Message: "Rate exceeded",
+				Type:    "ThrottlingException",
+			}
+
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusTooManyRequests)
+			json.NewEncoder(w).Encode(response)
+			return
+		}
+
+	}
+
+	response := Response{
+		UnprocessedTraceSegments: []TraceSegment{
+			{
+				Id:        "",
+				ErrorCode: "",
+				Message:   "",
+			},
+		},
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(response)
+}

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -1,0 +1,179 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+func Test_handleSetThrottled(t *testing.T) {
+	tests := []struct {
+		name          string
+		method        string
+		url           string
+		expectedCode  int
+		expectedState string
+		expectedRate  int
+	}{
+		{
+			name:          "Success with valid rate",
+			method:        http.MethodPost,
+			url:           "/SetThrottled?rate=50",
+			expectedCode:  http.StatusOK,
+			expectedState: StatusThrottled,
+			expectedRate:  50,
+		},
+		{
+			name:          "Invalid rate",
+			method:        http.MethodPost,
+			url:           "/SetThrottled?rate=DOGS",
+			expectedCode:  http.StatusBadRequest,
+			expectedState: StatusOK,
+			expectedRate:  0,
+		},
+		{
+			name:          "Default rate without rate parameter",
+			method:        http.MethodPost,
+			url:           "/SetThrottled",
+			expectedCode:  http.StatusOK,
+			expectedState: StatusThrottled,
+			expectedRate:  100,
+		},
+		{
+			name:          "Rate is 101",
+			method:        http.MethodPost,
+			url:           "/SetThrottled?rate=101",
+			expectedCode:  http.StatusBadRequest,
+			expectedState: StatusOK,
+			expectedRate:  0,
+		},
+		{
+			name:          "Bad method",
+			method:        http.MethodGet,
+			url:           "/SetThrottled",
+			expectedCode:  http.StatusMethodNotAllowed,
+			expectedState: StatusOK,
+			expectedRate:  0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger = zap.NewNop()
+			statusManager = NewStatusManager()
+			req := httptest.NewRequest(tt.method, tt.url, nil)
+			w := httptest.NewRecorder()
+
+			handleSetThrottled(w, req)
+
+			if w.Code != tt.expectedCode {
+				t.Errorf("handleSetThrottled() = %v, want %v", w.Code, tt.expectedCode)
+			}
+
+			status, rate := statusManager.GetStatus()
+			if status != tt.expectedState {
+				t.Errorf("statusManager.GetStatus() = %v, want %v", status, tt.expectedState)
+			}
+
+			if rate != tt.expectedRate {
+				t.Errorf("statusManager.GetStatus() = %v, want %v", rate, tt.expectedRate)
+			}
+		})
+	}
+}
+
+func Test_handleSetOK(t *testing.T) {
+	tests := []struct {
+		name          string
+		method        string
+		url           string
+		expectedCode  int
+		expectedState string
+	}{
+		{
+			name:          "Success",
+			method:        http.MethodPost,
+			url:           "/SetOK",
+			expectedCode:  http.StatusOK,
+			expectedState: StatusOK,
+		},
+		{
+			name:          "Bad method",
+			method:        http.MethodGet,
+			url:           "/SetOK",
+			expectedCode:  http.StatusMethodNotAllowed,
+			expectedState: StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger = zap.NewNop()
+			statusManager = NewStatusManager()
+			req := httptest.NewRequest(tt.method, tt.url, nil)
+			w := httptest.NewRecorder()
+
+			handleSetOK(w, req)
+
+			if w.Code != tt.expectedCode {
+				t.Errorf("handleSetOK() = %v, want %v", w.Code, tt.expectedCode)
+			}
+
+			status, _ := statusManager.GetStatus()
+			if status != tt.expectedState {
+				t.Errorf("statusManager.GetStatus() = %v, want %v", status, tt.expectedState)
+			}
+		})
+	}
+}
+
+func Test_handleTraceSegments(t *testing.T) {
+	tests := []struct {
+		name         string
+		method       string
+		url          string
+		throttleRate int
+		expectedCode int
+	}{
+		{
+			name:         "Success",
+			method:       http.MethodPost,
+			url:          "/TraceSegments",
+			throttleRate: 0,
+			expectedCode: http.StatusOK,
+		},
+		{
+			name:         "Bad method",
+			method:       http.MethodGet,
+			url:          "/TraceSegments",
+			throttleRate: 0,
+			expectedCode: http.StatusMethodNotAllowed,
+		},
+		{
+			name:         "Throttled",
+			method:       http.MethodPost,
+			url:          "/TraceSegments",
+			throttleRate: 100,
+			expectedCode: http.StatusTooManyRequests,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger = zap.NewNop()
+			statusManager = NewStatusManager()
+			req := httptest.NewRequest(tt.method, tt.url, nil)
+			w := httptest.NewRecorder()
+
+			statusManager.SetThrottled(tt.throttleRate)
+
+			handleTraceSegments(w, req)
+
+			if w.Code != tt.expectedCode {
+				t.Errorf("handleTraceSegments() = %v, want %v", w.Code, tt.expectedCode)
+			}
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -1,10 +1,8 @@
 package main
 
 import (
-	"encoding/json"
 	"flag"
 	"os"
-	"sync"
 
 	"net/http"
 
@@ -13,136 +11,15 @@ import (
 )
 
 var logger *zap.Logger
-var statusManager = NewStatusManager()
-var StatusOK = "OK"
-var StatusThrottled = "Throttled"
-var crtPath, keyPath string
-
-type StatusManager struct {
-	mutex  sync.RWMutex
-	status string
-}
-
-func NewStatusManager() *StatusManager {
-	return &StatusManager{
-		status: StatusOK,
-	}
-}
-
-func (sm *StatusManager) GetStatus() string {
-	sm.mutex.RLock()
-	defer sm.mutex.RUnlock()
-	return sm.status
-}
-
-func (sm *StatusManager) SetThrottled(status string) {
-	sm.mutex.Lock()
-	defer sm.mutex.Unlock()
-	sm.status = StatusThrottled
-	logger.Info("status changed", zap.String("status", sm.status))
-}
-
-func (sm *StatusManager) SetOK() {
-	sm.mutex.Lock()
-	defer sm.mutex.Unlock()
-	sm.status = StatusOK
-	logger.Info("status changed", zap.String("status", sm.status))
-}
-
-// Response represents the structure of our JSON response
-type Response struct {
-	UnprocessedTraceSegments []TraceSegment `json:"UnprocessedTraceSegments"`
-}
-
-// TraceSegment represents each segment in the response
-type TraceSegment struct {
-	Id        string `json:"Id"`
-	ErrorCode string `json:"ErrorCode"`
-	Message   string `json:"Message"`
-}
-
-// ThrottledException represents the structure of the error response
-type ThrottledException struct {
-	Message string `json:"message"`
-	Type    string `json:"__type"`
-}
-
-func handleSetOK(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
-		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
-		return
-	}
-
-	statusManager.SetOK()
-	w.WriteHeader(http.StatusOK)
-}
-
-func handleSetThrottled(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
-		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
-		return
-	}
-
-	statusManager.SetThrottled(StatusThrottled)
-	w.WriteHeader(http.StatusOK)
-}
-
-func handleTraceSegments(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
-		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
-		return
-	}
-
-	status := statusManager.GetStatus()
-
-	if status == StatusThrottled {
-		response := ThrottledException{
-			Message: "Rate exceeded",
-			Type:    "ThrottlingException",
-		}
-
-		logger.Info("Received request",
-			zap.String("method", r.Method),
-			zap.String("path", r.URL.Path),
-			zap.String("status_code", "429"),
-			zap.String("message", "Rate Exceeded"),
-			zap.String("user_agent", r.UserAgent()),
-		)
-
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusTooManyRequests)
-		json.NewEncoder(w).Encode(response)
-		return
-	} else {
-		response := Response{
-			UnprocessedTraceSegments: []TraceSegment{
-				{
-					Id:        "",
-					ErrorCode: "",
-					Message:   "",
-				},
-			},
-		}
-
-		logger.Info("Received request",
-			zap.String("method", r.Method),
-			zap.String("path", r.URL.Path),
-			zap.String("status_code", "200"),
-			zap.String("message", "ok"),
-			zap.String("user_agent", r.UserAgent()),
-		)
-
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		json.NewEncoder(w).Encode(response)
-	}
-}
+var statusManager *StatusManager
 
 func main() {
 	// Define flags for certificate and key file paths
 	certPath := flag.String("cert", "/path/to/cert.pem", "Path to the TLS certificate file")
 	keyPath := flag.String("key", "/path/to/key.pem", "Path to the TLS key file")
 	flag.Parse()
+
+	statusManager = NewStatusManager()
 
 	// Register handler for /TraceSegments path
 	http.HandleFunc("/TraceSegments", handleTraceSegments)

--- a/statusmanager.go
+++ b/statusmanager.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"sync"
+
+	"go.uber.org/zap"
+)
+
+var StatusOK = "OK"
+var StatusThrottled = "Throttled"
+
+type StatusManager struct {
+	mutex        sync.RWMutex
+	status       string
+	throttleRate int
+}
+
+func NewStatusManager() *StatusManager {
+	return &StatusManager{
+		status: StatusOK,
+	}
+}
+
+func (sm *StatusManager) GetStatus() (string, int) {
+	sm.mutex.RLock()
+	defer sm.mutex.RUnlock()
+	return sm.status, sm.throttleRate
+}
+
+func (sm *StatusManager) SetThrottled(rate int) {
+	sm.mutex.Lock()
+	defer sm.mutex.Unlock()
+	sm.status = StatusThrottled
+	sm.throttleRate = rate
+	logger.Info("status changed",
+		zap.String("status", sm.status),
+		zap.Int("throttle_rate", sm.throttleRate),
+	)
+}
+
+func (sm *StatusManager) SetOK() {
+	sm.mutex.Lock()
+	defer sm.mutex.Unlock()
+	sm.status = StatusOK
+	logger.Info("status changed", zap.String("status", sm.status))
+}


### PR DESCRIPTION
Configures the /SetThrottled endpoint to accept an integer that is used as a rate to probabilistically throttle requests.

Also adds tests, splits main into different files.