### PR TITLE
feat: adds rate limiting to the TraceSegments endpoint

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,9 @@ module github.com/hhtpcd/awsxraymock
 
 go 1.23.2
 
-require go.uber.org/zap v1.27.0
+require (
+	go.uber.org/zap v1.27.0
+	golang.org/x/time v0.8.0
+)
 
 require go.uber.org/multierr v1.11.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,5 +10,7 @@ go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
 go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
 go.uber.org/zap v1.27.0 h1:aJMhYGrd5QSmlpLMr2MftRKl7t8J8PTZPA732ud/XR8=
 go.uber.org/zap v1.27.0/go.mod h1:GB2qFLM7cTU87MWRP2mPIjqfIDnGu+VIO4V/SdhGo2E=
+golang.org/x/time v0.8.0 h1:9i3RxcPv3PZnitoVGMPDKZSq1xW1gK1Xy3ArNOGZfEg=
+golang.org/x/time v0.8.0/go.mod h1:3BpzKBy/shNhVucY/MWOyx10tF3SFh9QdLuxbVysPQM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+	"golang.org/x/time/rate"
 )
 
 var logger *zap.Logger
@@ -17,12 +18,14 @@ func main() {
 	// Define flags for certificate and key file paths
 	certPath := flag.String("cert", "/path/to/cert.pem", "Path to the TLS certificate file")
 	keyPath := flag.String("key", "/path/to/key.pem", "Path to the TLS key file")
+	rateLimit := flag.Float64("rate-limit", 2500, "Rate limit for the /TraceSegments endpoint")
+	rateBurst := flag.Int("rate-burst", 2500, "Rate burst for the /TraceSegments endpoint")
 	flag.Parse()
 
 	statusManager = NewStatusManager()
 
 	// Register handler for /TraceSegments path
-	http.HandleFunc("/TraceSegments", handleTraceSegments)
+	http.Handle("/TraceSegments", RateLimitHandler(http.HandlerFunc(handleTraceSegments), rate.Limit(*rateLimit), *rateBurst))
 	http.HandleFunc("/SetOK", handleSetOK)
 	http.HandleFunc("/SetThrottled", handleSetThrottled)
 
@@ -48,6 +51,7 @@ func main() {
 
 	// Start server on port 8080
 	logger.Info("Starting server on :8443")
+	logger.Info("Rate limit configured", zap.Float64("rate-limit", *rateLimit), zap.Int("rate-burst", *rateBurst))
 	if err := http.ListenAndServeTLS(":8443", *certPath, *keyPath, nil); err != nil {
 		logger.Fatal("Server failed to start: %v", zap.Error(err))
 	}


### PR DESCRIPTION
Rate limiting is closer to how the Xray API works instead of probablistic throttling of requests.

Rate limit is configurable with two flags.